### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.21.0
 opencv-contrib-python==4.5.5.62
 opencv-python==4.5.5.62
-python-dotenv==0.14.0
-sklearn==0.23.2
+python-dotenv==0.19.2
+sklearn==0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.21.0
-opencv-contrib-python==4.4.0.44
-opencv-python==4.4.0.44
+opencv-contrib-python==4.5.5.62
+opencv-python==4.5.5.62
 python-dotenv==0.14.0
 sklearn==0.23.2


### PR DESCRIPTION
# Related Issues or bug
  - Requirements.txt was not Up to date and previous versions of open-cv were not available.

## Fixes: #1073

# Proposed Changes
 - Changed the versions of requirements and all are now downloadable using pip.
 
